### PR TITLE
fix(package): remove unused hoek dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "hoek": "4.x.x",
     "moment": "2.x.x"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hoek had an [advisory](https://nodesecurity.io/advisories/566) come up on nsp. When I went to look at where it was used to see if this package was vulnerable, it appeared to me to not be in use anymore.

I removed hoek from package.json, all the tests still pass.