### PR TITLE
Add support for UTC parsing mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 .c9
 .idea
+.vscode
 .project
 *.iml
 npm-debug.log
 dump.rdb
 node_modules
+yarn.lock
+yarn-error.log
 results.tap
 results.xml
 npm-shrinkwrap.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,10 @@ module.exports = (joi) => ({
         }
 
         if (options.convert && this._flags.momentFormat) {
-            const date = Moment(value, this._flags.momentFormat, true);
+            const date = this._flags.utc
+                ? Moment.utc(value, this._flags.momentFormat, true)
+                : Moment(value, this._flags.momentFormat, true);
+
             if (date.isValid()) {
                 return date.toDate();
             }
@@ -45,6 +48,22 @@ module.exports = (joi) => ({
             setup(params) {
 
                 this._flags.momentFormat = params.format;
+            },
+            validate(params, value, state, options) {
+
+                // No-op just to enable description
+                return value;
+            }
+        },
+        {
+            name: 'utc',
+            description(params) {
+
+                return 'Date should be interpreted in UTC';
+            },
+            setup(params) {
+
+                this._flags.utc = true;
             },
             validate(params, value, state, options) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,13 @@ describe('date', () => {
             ], done);
         });
 
+        it('supports utc mode', (done) => {
+
+            Helper.validate(Joi.date().utc().format('YYYY-MM-DD'), [
+                ['2018-01-01', true, null, new Date('2018-01-01:00:00:00.000Z')]
+            ], done);
+        });
+
         it('fails with bad formats', (done) => {
 
             expect(() => {
@@ -88,7 +95,7 @@ describe('date', () => {
             });
         });
 
-        it('should be correctly described', (done) => {
+        it('should be correctly described (local mode)', (done) => {
 
             const schema = Joi.date().format(['DD#YYYY$MM', 'YY|DD|MM']);
             expect(schema.describe()).to.equal({
@@ -104,6 +111,43 @@ describe('date', () => {
                     }
                 },
                 rules: [
+                    {
+                        name: 'format',
+                        description: 'Date should respect format DD#YYYY$MM,YY|DD|MM',
+                        arg: {
+                            format: [
+                                'DD#YYYY$MM',
+                                'YY|DD|MM'
+                            ]
+                        }
+                    }
+                ]
+            });
+            done();
+        });
+
+        it('should be correctly described (utc mode)', (done) => {
+
+            const schema = Joi.date().utc().format(['DD#YYYY$MM', 'YY|DD|MM']);
+            expect(schema.describe()).to.equal({
+                type: 'date',
+                flags: {
+                    utc: true,
+                    momentFormat: ['DD#YYYY$MM', 'YY|DD|MM']
+                },
+                options: {
+                    language: {
+                        date: {
+                            format: 'must be a string with one of the following formats {{format}}'
+                        }
+                    }
+                },
+                rules: [
+                    {
+                        name: 'utc',
+                        description: 'Date should be interpreted in UTC',
+                        arg: {}
+                    },
                     {
                         name: 'format',
                         description: 'Date should respect format DD#YYYY$MM,YY|DD|MM',


### PR DESCRIPTION
When coercing a date string omitting the time part (e.g. `YYYY-MM-DD`), it was previously always parsed in local time. For example in the EST time zone, `2018-01-01` parsed to `2018-01-01:05:00:00.000Z`.

This PR adds an optional utc mode to `Joi.date()` coercion. Usage:

```js
const schema = Joi.date()
  .utc()
  .format('YYYY-MM-DD');
schema.validate('2018-01-01');
```

This parses to `2018-01-01:00:00:00.000Z` regardless of local time zone